### PR TITLE
Redo things w/o circular buffers

### DIFF
--- a/src/cobs_redo.rs
+++ b/src/cobs_redo.rs
@@ -1,0 +1,34 @@
+/// The first byte in the slice gets replaced by the offset to the first zero. This is the
+/// overhead byte
+fn cobs_encode(buf: &mut [u8]) {
+    let mut i_last_zero = 0;
+    for i in 1..buf.len() {
+        if buf[i] == 0u8 {
+            buf[i_last_zero] = (i-i_last_zero) as u8;
+            i_last_zero = i;
+        }
+    }
+    buf[i_last_zero] = 0xFFu8;
+}
+
+#[test]
+fn test_cobs_encode() {
+    let mut a1 = [0,1,2,3,4,5];
+    cobs_encode(&mut a1);
+    assert_eq!(a1,[255,1,2,3,4,5]);
+    let mut a1 = [0,0];
+    cobs_encode(&mut a1);
+    assert_eq!(a1,[1,255]);
+    let mut a1 = [0,0,0];
+    cobs_encode(&mut a1);
+    assert_eq!(a1,[1,1,255]);
+    let mut a1 = [0,0,1,0];
+    cobs_encode(&mut a1);
+    assert_eq!(a1,[1,2,1,255]);
+
+    let mut v1 = (0..0xFE).collect::<Vec::<u8>>();
+    let mut v2 = v1.clone();
+    v2[0] = 0xFF;
+    cobs_encode(&mut v1);
+    assert_eq!(v1,v2);
+}

--- a/src/cobs_redo.rs
+++ b/src/cobs_redo.rs
@@ -1,6 +1,8 @@
 /// The first byte in the slice gets replaced by the offset to the first zero. This is the
-/// overhead byte
-fn cobs_encode(buf: &mut [u8]) {
+/// overhead byte. 
+///
+/// The zero last has an offset of 255, assuming the end of the frame will come and it won't matter
+pub fn cobs_encode(buf: &mut [u8]) {
     let mut i_last_zero = 0;
     for i in 1..buf.len() {
         if buf[i] == 0u8 {
@@ -11,24 +13,66 @@ fn cobs_encode(buf: &mut [u8]) {
     buf[i_last_zero] = 0xFFu8;
 }
 
-#[test]
-fn test_cobs_encode() {
-    let mut a1 = [0,1,2,3,4,5];
-    cobs_encode(&mut a1);
-    assert_eq!(a1,[255,1,2,3,4,5]);
-    let mut a1 = [0,0];
-    cobs_encode(&mut a1);
-    assert_eq!(a1,[1,255]);
-    let mut a1 = [0,0,0];
-    cobs_encode(&mut a1);
-    assert_eq!(a1,[1,1,255]);
-    let mut a1 = [0,0,1,0];
-    cobs_encode(&mut a1);
-    assert_eq!(a1,[1,2,1,255]);
+/// The first byte in the slice is the overhead, so it is not part of the original message.
+/// Discard that byte.
+pub fn cobs_decode(buf: &mut [u8]) {
+    let mut i_next_zero = 0;
+    for i in 0..buf.len() {
+        if i == i_next_zero {
+            i_next_zero = (buf[i] as usize) + i;
+            buf[i] = 0u8;
+        }
+    }
+}
 
-    let mut v1 = (0..0xFE).collect::<Vec::<u8>>();
-    let mut v2 = v1.clone();
-    v2[0] = 0xFF;
-    cobs_encode(&mut v1);
-    assert_eq!(v1,v2);
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cobs_encode() {
+        let mut a1 = [0,1,2,3,4,5];
+        cobs_encode(&mut a1);
+        assert_eq!(a1,[255,1,2,3,4,5]);
+        let mut a1 = [0,1,2,3,4,5,0];
+        cobs_encode(&mut a1);
+        assert_eq!(a1,[6,1,2,3,4,5,255]);
+        let mut a1 = [0,0];
+        cobs_encode(&mut a1);
+        assert_eq!(a1,[1,255]);
+        let mut a1 = [0,0,0];
+        cobs_encode(&mut a1);
+        assert_eq!(a1,[1,1,255]);
+        let mut a1 = [0,0,1,0];
+        cobs_encode(&mut a1);
+        assert_eq!(a1,[1,2,1,255]);
+
+        let mut v1 = (0..0xFE).collect::<Vec::<u8>>();
+        let mut v2 = v1.clone();
+        v2[0] = 0xFF;
+        cobs_encode(&mut v1);
+        assert_eq!(v1,v2);
+    }
+
+    #[test]
+    fn test_cobs_decode() {
+        let mut a1 = [255,1,2,3,4,5];
+        cobs_decode(&mut a1);
+        assert_eq!(&a1[1..],(1u8..6).collect::<Vec<_>>());
+        let mut a1 = [6,1,2,3,4,5,255];
+        cobs_decode(&mut a1);
+        assert_eq!(&a1[1..],&[1,2,3,4,5,0]);
+        let mut a1 = [1,255];
+        cobs_decode(&mut a1);
+        assert_eq!(&a1[1..],&[0]);
+        let mut a1 = [1,1,255];
+        cobs_decode(&mut a1);
+        assert_eq!(&a1[1..],&[0,0]);
+        let mut a1 = [1,1,1,255];
+        cobs_decode(&mut a1);
+        assert_eq!(&a1[1..],&[0,0,0]);
+        let mut a1 = [1,2,1,255];
+        cobs_decode(&mut a1);
+        assert_eq!(&a1[1..],[0,1,0]);
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
-pub mod binarycom;
-pub mod circbuf;
-pub mod cobs;
-pub mod crc;
-pub mod error;
+//pub mod binarycom;
+//pub mod circbuf;
+//pub mod cobs;
+//pub mod crc;
+//pub mod error;
+pub mod cobs_redo;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,62 +1,62 @@
-use arraydeque::ArrayDeque;
-use arraydeque::Wrapping;
-
-use serial_com_rust::circbuf::CircBufExt;
-use serial_com_rust::cobs::COBSExt;
-use serial_com_rust::error::SerialComResult;
-
-fn main() -> SerialComResult<()> {
-    const CAPACITY: usize = 64;
-    let mut q: ArrayDeque<[u8; CAPACITY], Wrapping> = ArrayDeque::new();
-    q.push_back(0x22);
-    q.push_back(0x4);
-    println!("Capacity: {}", q.capacity());
-    println!("len: {}", q.len());
-    println!("is_empty: {}", q.is_empty());
-    println!("is_full: {}", q.is_full());
-    println!("contains 0: {}", q.contains(&0));
-    println!("contains 0x22: {}", q.contains(&0x22));
-    if let Some(val) = q.front() {
-        println!("front: {}", val);
-    }
-    if let Some(val) = q.back() {
-        println!("back: {}", val);
-    }
-    match q.get(0) {
-        Some(val) => println!("Element 0: {}", val),
-        None => println!("No element 0"),
-    }
-    match q.get(4) {
-        Some(val) => println!("Element 4: {}", val),
-        None => println!("No element 4"),
-    }
-    q.print();
-
-    q.push_back(0x0);
-    q.push_back(0x22);
-    q.push_back(0x3);
-    q.push_back(0x0);
-    q.push_back(0x9);
-    q.push_back(0xA);
-    let orig_q_1 = q.clone();
-    q.print();
-    q.cobs_encode()?;
-    q.print();
-    q.cobs_decode()?;
-    q.pop_back();
-    q.print();
-    println!("q1 equal: {}", q == orig_q_1);
-
-    q.clear();
-    q.push_back_rand(&32, &20);
-    let orig_q_2 = q.clone();
-    q.print();
-    q.cobs_encode()?;
-    q.print();
-    q.cobs_decode()?;
-    q.pop_back();
-    q.print();
-    println!("q2 equal: {}", q == orig_q_2);
-
-    Ok(())
-}
+//use arraydeque::ArrayDeque;
+//use arraydeque::Wrapping;
+//
+//use serial_com_rust::circbuf::CircBufExt;
+//use serial_com_rust::cobs::COBSExt;
+//use serial_com_rust::error::SerialComResult;
+//
+//fn main() -> SerialComResult<()> {
+//    const CAPACITY: usize = 64;
+//    let mut q: ArrayDeque<[u8; CAPACITY], Wrapping> = ArrayDeque::new();
+//    q.push_back(0x22);
+//    q.push_back(0x4);
+//    println!("Capacity: {}", q.capacity());
+//    println!("len: {}", q.len());
+//    println!("is_empty: {}", q.is_empty());
+//    println!("is_full: {}", q.is_full());
+//    println!("contains 0: {}", q.contains(&0));
+//    println!("contains 0x22: {}", q.contains(&0x22));
+//    if let Some(val) = q.front() {
+//        println!("front: {}", val);
+//    }
+//    if let Some(val) = q.back() {
+//        println!("back: {}", val);
+//    }
+//    match q.get(0) {
+//        Some(val) => println!("Element 0: {}", val),
+//        None => println!("No element 0"),
+//    }
+//    match q.get(4) {
+//        Some(val) => println!("Element 4: {}", val),
+//        None => println!("No element 4"),
+//    }
+//    q.print();
+//
+//    q.push_back(0x0);
+//    q.push_back(0x22);
+//    q.push_back(0x3);
+//    q.push_back(0x0);
+//    q.push_back(0x9);
+//    q.push_back(0xA);
+//    let orig_q_1 = q.clone();
+//    q.print();
+//    q.cobs_encode()?;
+//    q.print();
+//    q.cobs_decode()?;
+//    q.pop_back();
+//    q.print();
+//    println!("q1 equal: {}", q == orig_q_1);
+//
+//    q.clear();
+//    q.push_back_rand(&32, &20);
+//    let orig_q_2 = q.clone();
+//    q.print();
+//    q.cobs_encode()?;
+//    q.print();
+//    q.cobs_decode()?;
+//    q.pop_back();
+//    q.print();
+//    println!("q2 equal: {}", q == orig_q_2);
+//
+//    Ok(())
+//}


### PR DESCRIPTION
The code will be much simpler if circular buffers are avoided. The key to this seems to be to only start putting a message in the input buffer when a framing byte followed by a non-framing byte is found.